### PR TITLE
Add M365 Message Center new unread skill

### DIFF
--- a/.github/skills/m365-message-center-new-unread/.skill-meta.json
+++ b/.github/skills/m365-message-center-new-unread/.skill-meta.json
@@ -1,0 +1,11 @@
+{
+  "name": "m365-message-center-new-unread",
+  "source": "project",
+  "description": "Retrieve newly created, unread Microsoft 365 Message Center announcements while excluding updates to older posts.",
+  "categories": [
+    "microsoft-365",
+    "microsoft-graph",
+    "powershell"
+  ],
+  "installedAt": "2026-06-15T00:00:00.000Z"
+}

--- a/.github/skills/m365-message-center-new-unread/SKILL.md
+++ b/.github/skills/m365-message-center-new-unread/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: m365-message-center-new-unread
+description: 'Retrieve newly created, unread Microsoft 365 Message Center announcements for a specified period. Use when asked to find new M365 Message Center posts, exclude updates to older announcements, filter unread service announcements, or report recent Microsoft 365 changes through Microsoft Graph PowerShell.'
+---
+
+# Microsoft 365 Message Center New Unread
+
+Retrieve unread Message Center announcements whose `lastModifiedDateTime` is within a
+specified period, while excluding posts that Microsoft identifies as updates to older
+announcements.
+
+## Prerequisites
+
+- Use PowerShell 7 or later.
+- Install `Microsoft.Graph.Authentication` and
+  `Microsoft.Graph.Devices.ServiceAnnouncement`.
+- Connect with a delegated work or school account and the
+  `ServiceMessage.Read.All` scope:
+
+```powershell
+Connect-MgGraph -Scopes 'ServiceMessage.Read.All' -ContextScope Process
+```
+
+Do not use app-only authentication. Microsoft Graph returns `viewPoint` as `null` for
+application permissions, so unread status cannot be determined.
+
+## Workflow
+
+1. Ask the user for both the start and end timestamps if either is missing.
+2. Interpret the period as start-inclusive and end-exclusive.
+3. Connect to Microsoft Graph with delegated `ServiceMessage.Read.All` permission.
+4. Run the bundled script:
+
+```powershell
+./scripts/Get-M365MessageCenterNewUnread.ps1 `
+  -StartDateTime '2026-06-01T00:00:00+09:00' `
+  -EndDateTime '2026-06-08T00:00:00+09:00' `
+  -Verbose
+```
+
+5. Present the returned announcements in descending `LastModifiedDateTime` order.
+
+Use `-Verbose` when no objects are returned. It reports the number of messages retrieved,
+within the requested period, unread, and remaining after each update exclusion rule. An
+empty standard output with `New unread messages returned: 0` is a valid zero-result query.
+
+The script retrieves every page with `Get-MgServiceAnnouncementMessage -All`. It keeps
+only messages that meet all of these conditions:
+
+- `lastModifiedDateTime` is within the requested period.
+- `viewPoint.isRead` is explicitly `false`.
+- `tags` does not contain `Updated message`.
+- `title` does not begin with `(Updated)`.
+
+Use `lastModifiedDateTime` as the date criterion. Do not substitute or compare
+`startDateTime`.
+
+## Output
+
+Return objects containing:
+
+- `Id`
+- `Title`
+- `LastModifiedDateTime`
+- `Services`
+- `Category`
+- `Severity`
+- `ActionRequiredByDateTime`
+
+Keep this workflow read-only. Never call `markRead`, `markUnread`, archive, favorite, or
+other Message Center mutation operations.
+
+## Errors
+
+- If `viewPoint` is `null`, stop and explain that delegated authentication is required.
+- If the Graph modules are missing, identify the required modules without installing
+  them unless the user approves installation.
+- If the Graph session is missing or does not include `ServiceMessage.Read.All`, ask the
+  user to reconnect with the required delegated scope.
+- If the end timestamp is not later than the start timestamp, ask for a valid period.
+
+## References
+
+- [List serviceAnnouncement messages](https://learn.microsoft.com/en-us/graph/api/serviceannouncement-list-messages?view=graph-rest-1.0)
+- [serviceUpdateMessage resource](https://learn.microsoft.com/en-us/graph/api/resources/serviceupdatemessage?view=graph-rest-1.0)
+- [serviceUpdateMessageViewpoint resource](https://learn.microsoft.com/en-us/graph/api/resources/serviceupdatemessageviewpoint?view=graph-rest-1.0)

--- a/.github/skills/m365-message-center-new-unread/scripts/Get-M365MessageCenterNewUnread.ps1
+++ b/.github/skills/m365-message-center-new-unread/scripts/Get-M365MessageCenterNewUnread.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [DateTimeOffset] $StartDateTime,
+
+    [Parameter(Mandatory)]
+    [DateTimeOffset] $EndDateTime
+)
+
+Set-StrictMode -Version Latest
+
+function Select-M365MessageCenterNewUnread {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]] $Message,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $StartDateTime,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $EndDateTime
+    )
+
+    if ($EndDateTime -le $StartDateTime) {
+        throw 'EndDateTime must be later than StartDateTime.'
+    }
+
+    foreach ($item in $Message) {
+        if ($null -eq $item.ViewPoint) {
+            throw ('Message "{0}" has no viewPoint. Connect with delegated ServiceMessage.Read.All permission; app-only authentication cannot determine unread status.' -f $item.Id)
+        }
+    }
+
+    Write-Verbose ('Retrieved messages: {0}' -f $Message.Count)
+
+    $inPeriod = @(
+        $Message | Where-Object {
+            $lastModified = [DateTimeOffset] $_.LastModifiedDateTime
+            $lastModified -ge $StartDateTime -and $lastModified -lt $EndDateTime
+        }
+    )
+    Write-Verbose ('Messages in requested period: {0}' -f $inPeriod.Count)
+
+    $unread = @(
+        $inPeriod | Where-Object {
+            $null -ne $_.ViewPoint.IsRead -and $_.ViewPoint.IsRead -eq $false
+        }
+    )
+    Write-Verbose ('Unread messages in requested period: {0}' -f $unread.Count)
+
+    $withoutUpdatedTag = @(
+        $unread | Where-Object {
+            @($_.Tags) -notcontains 'Updated message'
+        }
+    )
+    Write-Verbose ('Unread messages excluding Updated message tags: {0}' -f $withoutUpdatedTag.Count)
+
+    $newUnread = @(
+        $withoutUpdatedTag | Where-Object {
+            $_.Title -notmatch '^\(Updated\)'
+        }
+    )
+    Write-Verbose ('New unread messages returned: {0}' -f $newUnread.Count)
+
+    $newUnread |
+        ForEach-Object {
+            [PSCustomObject]@{
+                Id                       = $_.Id
+                Title                    = $_.Title
+                LastModifiedDateTime     = [DateTimeOffset] $_.LastModifiedDateTime
+                Services                 = @($_.Services)
+                Category                 = $_.Category
+                Severity                 = $_.Severity
+                ActionRequiredByDateTime = if ($null -eq $_.ActionRequiredByDateTime) {
+                    $null
+                }
+                else {
+                    [DateTimeOffset] $_.ActionRequiredByDateTime
+                }
+            }
+        } |
+        Sort-Object -Property LastModifiedDateTime -Descending
+}
+
+function Get-M365MessageCenterNewUnread {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $StartDateTime,
+
+        [Parameter(Mandatory)]
+        [DateTimeOffset] $EndDateTime
+    )
+
+    if ($EndDateTime -le $StartDateTime) {
+        throw 'EndDateTime must be later than StartDateTime.'
+    }
+
+    if ($null -eq (Get-Command -Name Get-MgServiceAnnouncementMessage -ErrorAction SilentlyContinue)) {
+        throw 'Get-MgServiceAnnouncementMessage is unavailable. Install Microsoft.Graph.Devices.ServiceAnnouncement.'
+    }
+
+    if ($null -eq (Get-Command -Name Get-MgContext -ErrorAction SilentlyContinue)) {
+        throw 'Get-MgContext is unavailable. Install Microsoft.Graph.Authentication.'
+    }
+
+    $context = Get-MgContext
+    if ($null -eq $context) {
+        throw "No Microsoft Graph session exists. Run Connect-MgGraph -Scopes 'ServiceMessage.Read.All' -ContextScope Process."
+    }
+
+    if ($context.AuthType -eq 'AppOnly') {
+        throw 'App-only authentication cannot determine unread status. Connect with delegated ServiceMessage.Read.All permission.'
+    }
+
+    if (@($context.Scopes) -notcontains 'ServiceMessage.Read.All') {
+        throw "The Microsoft Graph session lacks ServiceMessage.Read.All. Reconnect with Connect-MgGraph -Scopes 'ServiceMessage.Read.All' -ContextScope Process."
+    }
+
+    $properties = @(
+        'id'
+        'title'
+        'lastModifiedDateTime'
+        'services'
+        'category'
+        'severity'
+        'actionRequiredByDateTime'
+        'tags'
+        'viewPoint'
+    )
+
+    $messages = @(Get-MgServiceAnnouncementMessage -All -Property $properties)
+    Select-M365MessageCenterNewUnread -Message $messages -StartDateTime $StartDateTime -EndDateTime $EndDateTime
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Get-M365MessageCenterNewUnread -StartDateTime $StartDateTime -EndDateTime $EndDateTime
+}

--- a/.github/skills/m365-message-center-new-unread/tests/Get-M365MessageCenterNewUnread.Tests.ps1
+++ b/.github/skills/m365-message-center-new-unread/tests/Get-M365MessageCenterNewUnread.Tests.ps1
@@ -1,0 +1,122 @@
+$scriptPath = Join-Path $PSScriptRoot '..\scripts\Get-M365MessageCenterNewUnread.ps1'
+. $scriptPath -StartDateTime '2026-06-01T00:00:00Z' -EndDateTime '2026-06-08T00:00:00Z'
+
+function New-TestMessage {
+    param(
+        [string] $Id,
+        [string] $Title = 'New feature',
+        [string] $LastModifiedDateTime = '2026-06-03T00:00:00Z',
+        [AllowNull()]
+        [object] $IsRead = $false,
+        [AllowNull()]
+        [object] $ViewPoint = ([PSCustomObject]@{ IsRead = $IsRead }),
+        [string[]] $Tags = @()
+    )
+
+    [PSCustomObject]@{
+        Id                       = $Id
+        Title                    = $Title
+        LastModifiedDateTime     = $LastModifiedDateTime
+        Services                 = @('Microsoft 365')
+        Category                 = 'planForChange'
+        Severity                 = 'normal'
+        ActionRequiredByDateTime = $null
+        Tags                     = $Tags
+        ViewPoint                = $ViewPoint
+    }
+}
+
+Describe 'Select-M365MessageCenterNewUnread' {
+    $start = [DateTimeOffset] '2026-06-01T00:00:00Z'
+    $end = [DateTimeOffset] '2026-06-08T00:00:00Z'
+
+    It 'keeps only new unread messages and sorts newest first' {
+        $messages = @(
+            (New-TestMessage -Id 'MC1' -LastModifiedDateTime '2026-06-01T00:00:00Z')
+            (New-TestMessage -Id 'MC2' -LastModifiedDateTime '2026-06-07T23:59:59Z')
+            (New-TestMessage -Id 'READ' -IsRead $true)
+            (New-TestMessage -Id 'TAGGED' -Tags @('Updated message'))
+            (New-TestMessage -Id 'TITLE' -Title '(Updated) Existing feature')
+            (New-TestMessage -Id 'BEFORE' -LastModifiedDateTime '2026-05-31T23:59:59Z')
+            (New-TestMessage -Id 'END' -LastModifiedDateTime '2026-06-08T00:00:00Z')
+        )
+
+        $result = @(Select-M365MessageCenterNewUnread -Message $messages -StartDateTime $start -EndDateTime $end)
+
+        $result.Count | Should Be 2
+        $result[0].Id | Should Be 'MC2'
+        $result[1].Id | Should Be 'MC1'
+    }
+
+    It 'excludes a message when unread status is not explicit' {
+        $message = New-TestMessage -Id 'UNKNOWN' -IsRead $null
+
+        $result = @(Select-M365MessageCenterNewUnread -Message @($message) -StartDateTime $start -EndDateTime $end)
+
+        $result.Count | Should Be 0
+    }
+
+    It 'rejects an invalid period' {
+        $thrown = $false
+        try {
+            Select-M365MessageCenterNewUnread -Message @() -StartDateTime $end -EndDateTime $start
+        }
+        catch {
+            $thrown = $true
+        }
+
+        $thrown | Should Be $true
+    }
+
+    It 'rejects a null viewpoint' {
+        $message = New-TestMessage -Id 'APPONLY' -ViewPoint $null
+
+        $thrown = $false
+        try {
+            Select-M365MessageCenterNewUnread -Message @($message) -StartDateTime $start -EndDateTime $end
+        }
+        catch {
+            $thrown = $true
+        }
+
+        $thrown | Should Be $true
+    }
+}
+
+Describe 'Get-M365MessageCenterNewUnread' {
+    function Get-MgServiceAnnouncementMessage {
+        param(
+            [switch] $All,
+            [string[]] $Property
+        )
+    }
+    function Get-MgContext {}
+
+    Mock Get-Command {
+        [PSCustomObject]@{ Name = $Name }
+    }
+    Mock Get-MgContext {
+        [PSCustomObject]@{
+            AuthType = 'Delegated'
+            Scopes   = @('ServiceMessage.Read.All')
+        }
+    }
+    $script:graphCalledWithAll = $false
+    Mock Get-MgServiceAnnouncementMessage {
+        $script:graphCalledWithAll = [bool] $All
+        @(
+            (New-TestMessage -Id 'NEW')
+            (New-TestMessage -Id 'OLD-UPDATE' -Tags @('Updated message'))
+        )
+    }
+
+    It 'retrieves all pages and filters the Graph response' {
+        $result = @(Get-M365MessageCenterNewUnread `
+            -StartDateTime '2026-06-01T00:00:00Z' `
+            -EndDateTime '2026-06-08T00:00:00Z')
+
+        $result.Count | Should Be 1
+        $result[0].Id | Should Be 'NEW'
+        $script:graphCalledWithAll | Should Be $true
+    }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 | [import-infrastructure-as-code](.github/skills/import-infrastructure-as-code/SKILL.md) | Import existing Azure resources into Terraform using Azure CLI discovery and Azure Verified Modules (AVM). Use when asked to reverse-engineer live Azure infrastructure or generate IaC from existing Azure resources. |
 | [microsoft-code-reference](.github/skills/microsoft-code-reference/SKILL.md) | Look up Microsoft API references, find working code samples, and verify SDK code is correct. |
 | [microsoft-docs](.github/skills/microsoft-docs/SKILL.md) | Query official Microsoft documentation to find concepts, tutorials, and code examples across Azur... \| Research skill for the Microsoft technology ecosystem. Covers learn.microsoft.com and documentati... |
+| [m365-message-center-new-unread](.github/skills/m365-message-center-new-unread/SKILL.md) | Retrieve newly created, unread Microsoft 365 Message Center announcements for a specified period while excluding updates to older posts. |
 | [nuget-manager](.github/skills/nuget-manager/SKILL.md) | Manage NuGet packages in .NET projects/solutions. |
 | [nuget-validate](.github/skills/nuget-validate/SKILL.md) | Validate NuGet package versions for vulnerabilities, deprecation, freshness, and listing status before package changes. |
 | [semantic-kernel](.github/skills/semantic-kernel/SKILL.md) | Create, update, refactor, explain, or review Semantic Kernel solutions using shared guidance plus language-specific references for .NET and Python. |


### PR DESCRIPTION
## Summary
- add a Microsoft 365 Message Center skill backed by Microsoft Graph PowerShell
- return only unread announcements whose lastModifiedDateTime is within the requested period
- exclude older announcements marked with the Updated message tag or (Updated) title prefix
- add verbose filter-stage diagnostics, mocked Pester coverage, and skill registration

## Authentication and behavior
- requires delegated ServiceMessage.Read.All
- rejects app-only authentication because viewPoint is unavailable
- remains read-only and never changes Message Center state

## Validation
- Pester: 5 passed, 0 failed
- PowerShell syntax validation passed
- quick_validate.py: Skill is valid
- live tenant validation confirmed that marking one in-period message unread returns exactly that message

Closes #8