### PR TITLE
[update]: harden Azure DevOps Work Item registration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Skills and plugins for Azure DevOps, .NET, and NuGet workflows.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "azure-devops-toolkit",
       "description": "Azure DevOps skills and agents for Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, and Advanced Security.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "source": "./plugins/azure-devops-toolkit",
       "license": "MIT",
       "keywords": [

--- a/.github/agents/azure-devops-work-item-agent.agent.md
+++ b/.github/agents/azure-devops-work-item-agent.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 'Azure DevOps Work Item Agent'
-description: 'Creates Azure DevOps work items with process-aware hierarchy, iteration, assignee, and bug-linking rules.'
+description: 'Creates Azure DevOps work items with process-aware hierarchy, iteration, assignee, bug-linking, Windows-native execution, and mandatory Wiki handoff for Feature-equivalent items.'
 tools: ['codebase', 'search', 'terminalCommand', 'runCommands', 'githubRepo', 'edit/editFiles']
 ---
 
@@ -12,6 +12,7 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 
 - [azure-devops-foundation](../skills/azure-devops-foundation/SKILL.md)
 - [azure-devops-boards](../skills/azure-devops-boards/SKILL.md)
+- [azure-devops-wiki](../skills/azure-devops-wiki/SKILL.md)
 
 ## Core rules
 
@@ -21,6 +22,28 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 4. If a required parent item is missing, create it first.
 5. Keep traceability: every created item should explain why it exists and how it relates to the plan.
 
+## Feature-equivalent Wiki gate
+
+After resolving the process and backlog metadata, classify the requirement item before creating it:
+
+- Agile, Scrum, or CMMI Feature
+- Basic Issue, because Basic has no separate Feature type
+- A custom type mapped to the same portfolio/backlog level as Feature
+
+Treat User Story, Product Backlog Item, Requirement, Task, and Bug as non-gated unless the project metadata explicitly maps them to the Feature level. Ask when the mapping is ambiguous.
+
+For a gated item:
+
+1. Read the azure-devops-wiki skill and discover the existing Wiki, parent page, and target path using read operations.
+2. Do not create, rename, reorder, or re-index Wiki structure. Stop before Work Item creation if the existing destination cannot be determined.
+3. Obtain confirmation for the page draft when the Wiki skill requires it.
+4. Create the Work Item hierarchy only after Wiki preflight succeeds.
+5. Load and run azure-devops-wiki as an explicit handoff, passing the Work Item ID, title, approved plan, and existing page path.
+6. Read the page back and verify the Work Item ID and plan before reporting success.
+
+If the Wiki write unexpectedly fails after creation, keep the Work Item, report a partial failure, and identify Wiki registration as the required retry. Never delete the Work Item to simulate rollback.
+
+
 ## Hierarchy by process
 
 | Process | Hierarchy |
@@ -28,6 +51,7 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 | Basic | Epic > Issue > Task |
 | Agile | Epic > Feature > User Story > Task |
 | Scrum | Epic > Feature > Product Backlog Item > Task |
+| CMMI | Epic > Feature > Requirement > Task |
 
 ## Defect handling
 
@@ -55,12 +79,20 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 
 ## Creation order
 
-1. Resolve process template and existing hierarchy.
-2. Create any missing parent items.
-3. Create the requirement item.
-4. Create tasks underneath it.
-5. Create bugs for defects and link them to the relevant task.
-6. Set iteration, assignee, due date, and any other required fields.
+1. Resolve process template, backlog levels, and existing hierarchy.
+2. Classify whether the requirement is Feature-equivalent and complete Wiki preflight when required.
+3. Create any missing parent items.
+4. Create the requirement item.
+5. Create tasks underneath it.
+6. Create bugs for defects and link them to the relevant task.
+7. Set iteration, assignee, due date, and any other required fields.
+8. Complete the azure-devops-wiki handoff and read-back verification before reporting a gated item as successful.
+
+## Windows execution
+
+## Windows execution
+
+Read the Boards skill's Windows-native execution reference. On Windows, use MCP first, then PowerShell 7 Invoke-RestMethod, then native az boards. Never invoke MSYS2, Git Bash, WSL, bash, or sh. If az output appears corrupted, read the stored Work Item back through Invoke-RestMethod and do not translate user content.
 
 ## Guardrails
 

--- a/.github/agents/azure-devops-work-item-agent.agent.md
+++ b/.github/agents/azure-devops-work-item-agent.agent.md
@@ -90,8 +90,6 @@ If the Wiki write unexpectedly fails after creation, keep the Work Item, report 
 
 ## Windows execution
 
-## Windows execution
-
 Read the Boards skill's Windows-native execution reference. On Windows, use MCP first, then PowerShell 7 Invoke-RestMethod, then native az boards. Never invoke MSYS2, Git Bash, WSL, bash, or sh. If az output appears corrupted, read the stored Work Item back through Invoke-RestMethod and do not translate user content.
 
 ## Guardrails

--- a/.github/skills/azure-devops-boards/SKILL.md
+++ b/.github/skills/azure-devops-boards/SKILL.md
@@ -1,12 +1,24 @@
 ---
 name: azure-devops-boards
-description: 'Manage Azure Boards work items: create, update fields, add comments, link items, and close them. Use when the user asks to create/update/comment on/close bugs, tasks, user stories, or other work items in Azure DevOps. Prefers Azure DevOps MCP Server tools and falls back to the REST API.'
-compatibility: 'Azure DevOps Services. MCP tools require the Azure DevOps MCP Server (wit toolset).'
+description: 'Manage Azure Boards work items: create, update fields, add comments, link items, and close them. Use when the user asks to create/update/comment on/close bugs, tasks, user stories, features, or other work items in Azure DevOps. Prefer Azure DevOps MCP Server tools, then use Windows-native PowerShell Invoke-RestMethod or az boards on Windows, and fall back to REST/CLI on non-Windows systems. Feature-equivalent work items require a delegated Azure DevOps Wiki registration before completion.'
 ---
 
 # Azure Boards Work Items
 
-Create, update, comment on, link, and close Azure Boards work items. Read [azure-devops-foundation](../azure-devops-foundation/SKILL.md) first for the MCP-first/REST-fallback strategy and authentication.
+Create, update, comment on, link, and close Azure Boards work items. Read [azure-devops-foundation](../azure-devops-foundation/SKILL.md) first for the MCP-first strategy and authentication.
+
+
+## Execution policy
+
+Follow this order for every operation:
+
+1. Use Azure DevOps MCP tools when they are available.
+2. When MCP is unavailable on Windows, use PowerShell 7 with Invoke-RestMethod first. Use native az boards from PowerShell only as the next fallback.
+3. On Linux and macOS, use the REST/CLI fallback described below.
+
+On Windows, never invoke Azure DevOps operations through MSYS2, Git Bash, WSL, bash, or sh. If only one of those shells is available, stop and report that a native PowerShell path is required. Read [Windows-native execution reference](references/windows-native-execution.md) for the encoding-safe command patterns.
+
+Do not rewrite Japanese or other non-English content because captured az output looks corrupted. Redirected output can be encoded with the Windows ANSI code page even when the server data is intact. Read the stored value back with Invoke-RestMethod before diagnosing data loss.
 
 ## When to use
 
@@ -16,6 +28,27 @@ Create, update, comment on, link, and close Azure Boards work items. Read [azure
 - Closing or transitioning work items (close = state transition)
 - Querying work items (saved queries, backlogs, full-text search)
 - Linking work items to each other or to pull requests/commits/builds
+
+
+## Feature-equivalent Wiki gate
+
+Before creating a requirement-level item, query the project process and backlog metadata. Treat these types as Feature-equivalent and require Wiki registration:
+
+- Feature in Agile, Scrum, or CMMI processes
+- Issue in the Basic process, which has no separate Feature type
+- A custom type assigned to the same portfolio/backlog level as Feature
+
+Do not trigger this gate for a User Story, Product Backlog Item, Requirement, Task, or Bug unless the project metadata explicitly maps that type to the Feature level. If the mapping is ambiguous, ask instead of guessing.
+
+For a Feature-equivalent item, follow this sequence:
+
+1. Read [azure-devops-wiki](../azure-devops-wiki/SKILL.md) and discover the existing Wiki, parent page, and page path using read operations. Do not create, rename, reorder, or re-index Wiki structure.
+2. Confirm that the existing placement can be used and that the approved plan has a concrete page destination. If the Wiki or destination cannot be determined, do not create the Work Item.
+3. Create the Work Item hierarchy only after the Wiki preflight succeeds.
+4. Explicitly load and run azure-devops-wiki, handing it the Work Item ID, title, approved plan, and existing page path. Do not duplicate Wiki page-writing logic in this skill or agent.
+5. Read the page back and verify that the registration contains the Work Item ID and approved plan. Report the Feature operation as successful only after this verification.
+
+If an unexpected Wiki write fails after the Work Item exists, do not delete the Work Item. Report the created ID as a partial failure and identify Wiki registration as the required retry.
 
 ## MCP tools (preferred)
 

--- a/.github/skills/azure-devops-boards/references/windows-native-execution.md
+++ b/.github/skills/azure-devops-boards/references/windows-native-execution.md
@@ -1,0 +1,62 @@
+# Windows-Native Azure DevOps Execution
+
+Use this reference whenever Azure Boards work is executed from Windows, especially on a non-English Windows installation.
+
+## Required shell selection
+
+1. Use Azure DevOps MCP tools when available.
+2. Otherwise run PowerShell 7 (pwsh) and prefer Invoke-RestMethod.
+3. Use the native az boards command from PowerShell only when REST is impractical.
+
+Never use MSYS2, Git Bash, WSL, bash, or sh for Azure DevOps work on Windows. Do not use MSYS_NO_PATHCONV as a workaround; that variable addresses path conversion in a prohibited shell and does not make the shell an approved execution path.
+
+## UTF-8 REST writes
+
+Keep the organization URL, project, and token in environment variables. Do not print the token.
+
+PowerShell example:
+
+    $orgUrl = $env:ADO_ORG_URL.TrimEnd('/')
+    $project = [Uri]::EscapeDataString($env:ADO_PROJECT)
+    $typeName = [Uri]::EscapeDataString($env:ADO_WORK_ITEM_TYPE)
+    $title = $env:ADO_WORK_ITEM_TITLE
+    $description = $env:ADO_WORK_ITEM_DESCRIPTION
+
+    $patch = @(
+        @{ op = 'add'; path = '/fields/System.Title'; value = $title },
+        @{ op = 'add'; path = '/fields/System.Description'; value = $description }
+    )
+    $json = $patch | ConvertTo-Json -Depth 10 -Compress
+    $body = [Text.Encoding]::UTF8.GetBytes($json)
+    $headers = @{ Authorization = "Bearer $env:ADO_TOKEN" }
+    $workItemsSegment = '$' + $typeName
+    $uri = "$orgUrl/$project/_apis/wit/workitems/$workItemsSegment?api-version=7.1"
+
+    $created = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -ContentType 'application/json-patch+json; charset=utf-8' -Body $body
+    $created.id
+
+Use the same UTF-8 byte conversion for JSON Patch updates and relation links. Read the created item back with Invoke-RestMethod; PowerShell returns the response as Unicode text without relying on the console code page.
+
+## Native az boards fallback
+
+Use az boards directly from PowerShell and retrieve only an ASCII ID when possible:
+
+    $createdId = az boards work-item create --type $env:ADO_WORK_ITEM_TYPE --title $env:ADO_WORK_ITEM_TITLE --description $env:ADO_WORK_ITEM_DESCRIPTION --query id -o tsv
+
+Verify fields with Invoke-RestMethod rather than trusting captured human-readable az output. Azure CLI's MSI launcher uses Python isolated mode, which ignores PYTHONIOENCODING; redirected output can therefore use the Windows ANSI code page. chcp 65001 changes the console code page and does not repair redirected output. Neither behavior means that the server received corrupted data.
+
+If az emits an encoding warning, preserve the original title and description, read the Work Item through REST, and compare the returned fields. Never translate content to English as an encoding workaround.
+
+## Linux/macOS comparison
+
+The following pattern is for Linux/macOS shells only. It must not be copied into a Windows MSYS2 or Git Bash session.
+
+    base_uri="$ADO_ORG_URL/$ADO_PROJECT"
+    json="$PATCH_JSON"
+    curl --fail-with-body -sS -X POST \
+      -H "Authorization: Bearer $ADO_TOKEN" \
+      -H 'Content-Type: application/json-patch+json; charset=utf-8' \
+      --data-binary "$json" \
+      "$base_uri/_apis/wit/workitems/\$$ADO_WORK_ITEM_TYPE?api-version=7.1"
+
+When a Windows session cannot provide PowerShell 7, stop and request that the user run the operation from a native PowerShell environment. Do not silently switch to MSYS2.

--- a/.github/skills/azure-devops-boards/references/windows-native-execution.md
+++ b/.github/skills/azure-devops-boards/references/windows-native-execution.md
@@ -12,7 +12,7 @@ Never use MSYS2, Git Bash, WSL, bash, or sh for Azure DevOps work on Windows. Do
 
 ## UTF-8 REST writes
 
-Keep the organization URL, project, and token in environment variables. Do not print the token.
+Keep the organization URL, project, and credential in environment variables. In the PowerShell example below, `ADO_TOKEN` must be an Entra ID access token because it is sent as a Bearer token. A PAT is not a Bearer token; use an `Authorization: Basic` header with the PAT instead, following the authentication guidance in the foundation skill. Never print credentials.
 
 PowerShell example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0
+
+- Hardened Azure Boards Work Item registration for non-English Windows with native PowerShell and UTF-8 read-back verification.
+- Added mandatory Azure DevOps Wiki handoff and verification for Feature-equivalent Work Items.
+- Synchronized Codex, Claude, and GitHub Copilot plugin metadata and mirrors.
+
 ## 0.1.0
 
 - Added the `azure-devops-toolkit` plugin bundle.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal plugins for Azure DevOps and .NET package maintenance (skills + agents)
 
 | Plugin | Included skills and agents |
 |---|---|
-| `azure-devops-toolkit` | Skills: Azure DevOps Foundation, Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, Advanced Security, CLI, security triage. Agents: Azure DevOps Agent, Azure DevOps Work Item Agent |
+| `azure-devops-toolkit` | Skills: Azure DevOps Foundation, Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, Advanced Security, CLI, security triage. Boards uses native PowerShell on Windows and Feature-equivalent Work Items require Wiki traceability. Agents: Azure DevOps Agent, Azure DevOps Work Item Agent |
 | `nuget-validate` | NuGet vulnerability, deprecation, listing, freshness, and project-audit validation |
 | `dependabot-safe-merge` | Safe Dependabot refresh, release-age policy, merge gates, and major-upgrade planning |
 | `github-plan-wiki` | Skills: GitHub Plan Issues (parent + sub-issue hierarchy via `gh`), GitHub Wiki Plan (bilingual GitHub wiki publishing and Home index maintenance) |

--- a/plugins/azure-devops-toolkit/.claude-plugin/plugin.json
+++ b/plugins/azure-devops-toolkit/.claude-plugin/plugin.json
@@ -1,11 +1,16 @@
 {
   "name": "azure-devops-toolkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Azure DevOps skills and agents for Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, and Advanced Security.",
   "author": {
     "name": "Team Foundation Users Japan"
   },
   "license": "MIT",
-  "keywords": ["azure", "azure-devops", "devops", "security"],
+  "keywords": [
+    "azure",
+    "azure-devops",
+    "devops",
+    "security"
+  ],
   "skills": "./skills/"
 }

--- a/plugins/azure-devops-toolkit/.codex-plugin/plugin.json
+++ b/plugins/azure-devops-toolkit/.codex-plugin/plugin.json
@@ -1,12 +1,17 @@
 {
   "name": "azure-devops-toolkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Azure DevOps skills and agents for Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, and Advanced Security.",
   "author": {
     "name": "Team Foundation Users Japan"
   },
   "license": "MIT",
-  "keywords": ["azure", "azure-devops", "devops", "security"],
+  "keywords": [
+    "azure",
+    "azure-devops",
+    "devops",
+    "security"
+  ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Azure DevOps Toolkit",
@@ -14,9 +19,12 @@
     "longDescription": "A plugin with skills and custom agents for Azure Boards, Repos, Pipelines, Artifacts, Test Plans, Wikis, and Advanced Security workflows.",
     "developerName": "Team Foundation Users Japan",
     "category": "Developer Tools",
-    "capabilities": ["Read", "Write"],
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
     "defaultPrompt": [
-      "Review this Azure DevOps workflow and identify the next action.",
+      "Create a process-aware Azure Boards work item with safe traceability.",
       "Help me triage this Azure DevOps security alert.",
       "Plan the safest Azure DevOps pipeline change."
     ]

--- a/plugins/azure-devops-toolkit/agents/azure-devops-work-item-agent.agent.md
+++ b/plugins/azure-devops-toolkit/agents/azure-devops-work-item-agent.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 'Azure DevOps Work Item Agent'
-description: 'Creates Azure DevOps work items with process-aware hierarchy, iteration, assignee, and bug-linking rules.'
+description: 'Creates Azure DevOps work items with process-aware hierarchy, iteration, assignee, bug-linking, Windows-native execution, and mandatory Wiki handoff for Feature-equivalent items.'
 tools: ['codebase', 'search', 'terminalCommand', 'runCommands', 'githubRepo', 'edit/editFiles']
 ---
 
@@ -12,6 +12,7 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 
 - [azure-devops-foundation](../skills/azure-devops-foundation/SKILL.md)
 - [azure-devops-boards](../skills/azure-devops-boards/SKILL.md)
+- [azure-devops-wiki](../skills/azure-devops-wiki/SKILL.md)
 
 ## Core rules
 
@@ -21,6 +22,28 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 4. If a required parent item is missing, create it first.
 5. Keep traceability: every created item should explain why it exists and how it relates to the plan.
 
+## Feature-equivalent Wiki gate
+
+After resolving the process and backlog metadata, classify the requirement item before creating it:
+
+- Agile, Scrum, or CMMI Feature
+- Basic Issue, because Basic has no separate Feature type
+- A custom type mapped to the same portfolio/backlog level as Feature
+
+Treat User Story, Product Backlog Item, Requirement, Task, and Bug as non-gated unless the project metadata explicitly maps them to the Feature level. Ask when the mapping is ambiguous.
+
+For a gated item:
+
+1. Read the azure-devops-wiki skill and discover the existing Wiki, parent page, and target path using read operations.
+2. Do not create, rename, reorder, or re-index Wiki structure. Stop before Work Item creation if the existing destination cannot be determined.
+3. Obtain confirmation for the page draft when the Wiki skill requires it.
+4. Create the Work Item hierarchy only after Wiki preflight succeeds.
+5. Load and run azure-devops-wiki as an explicit handoff, passing the Work Item ID, title, approved plan, and existing page path.
+6. Read the page back and verify the Work Item ID and plan before reporting success.
+
+If the Wiki write unexpectedly fails after creation, keep the Work Item, report a partial failure, and identify Wiki registration as the required retry. Never delete the Work Item to simulate rollback.
+
+
 ## Hierarchy by process
 
 | Process | Hierarchy |
@@ -28,6 +51,7 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 | Basic | Epic > Issue > Task |
 | Agile | Epic > Feature > User Story > Task |
 | Scrum | Epic > Feature > Product Backlog Item > Task |
+| CMMI | Epic > Feature > Requirement > Task |
 
 ## Defect handling
 
@@ -55,12 +79,20 @@ You create Azure DevOps work items from a plan, keeping hierarchy, iteration, as
 
 ## Creation order
 
-1. Resolve process template and existing hierarchy.
-2. Create any missing parent items.
-3. Create the requirement item.
-4. Create tasks underneath it.
-5. Create bugs for defects and link them to the relevant task.
-6. Set iteration, assignee, due date, and any other required fields.
+1. Resolve process template, backlog levels, and existing hierarchy.
+2. Classify whether the requirement is Feature-equivalent and complete Wiki preflight when required.
+3. Create any missing parent items.
+4. Create the requirement item.
+5. Create tasks underneath it.
+6. Create bugs for defects and link them to the relevant task.
+7. Set iteration, assignee, due date, and any other required fields.
+8. Complete the azure-devops-wiki handoff and read-back verification before reporting a gated item as successful.
+
+## Windows execution
+
+## Windows execution
+
+Read the Boards skill's Windows-native execution reference. On Windows, use MCP first, then PowerShell 7 Invoke-RestMethod, then native az boards. Never invoke MSYS2, Git Bash, WSL, bash, or sh. If az output appears corrupted, read the stored Work Item back through Invoke-RestMethod and do not translate user content.
 
 ## Guardrails
 

--- a/plugins/azure-devops-toolkit/agents/azure-devops-work-item-agent.agent.md
+++ b/plugins/azure-devops-toolkit/agents/azure-devops-work-item-agent.agent.md
@@ -90,8 +90,6 @@ If the Wiki write unexpectedly fails after creation, keep the Work Item, report 
 
 ## Windows execution
 
-## Windows execution
-
 Read the Boards skill's Windows-native execution reference. On Windows, use MCP first, then PowerShell 7 Invoke-RestMethod, then native az boards. Never invoke MSYS2, Git Bash, WSL, bash, or sh. If az output appears corrupted, read the stored Work Item back through Invoke-RestMethod and do not translate user content.
 
 ## Guardrails

--- a/plugins/azure-devops-toolkit/skills/azure-devops-boards/SKILL.md
+++ b/plugins/azure-devops-toolkit/skills/azure-devops-boards/SKILL.md
@@ -1,12 +1,24 @@
 ---
 name: azure-devops-boards
-description: 'Manage Azure Boards work items: create, update fields, add comments, link items, and close them. Use when the user asks to create/update/comment on/close bugs, tasks, user stories, or other work items in Azure DevOps. Prefers Azure DevOps MCP Server tools and falls back to the REST API.'
-compatibility: 'Azure DevOps Services. MCP tools require the Azure DevOps MCP Server (wit toolset).'
+description: 'Manage Azure Boards work items: create, update fields, add comments, link items, and close them. Use when the user asks to create/update/comment on/close bugs, tasks, user stories, features, or other work items in Azure DevOps. Prefer Azure DevOps MCP Server tools, then use Windows-native PowerShell Invoke-RestMethod or az boards on Windows, and fall back to REST/CLI on non-Windows systems. Feature-equivalent work items require a delegated Azure DevOps Wiki registration before completion.'
 ---
 
 # Azure Boards Work Items
 
-Create, update, comment on, link, and close Azure Boards work items. Read [azure-devops-foundation](../azure-devops-foundation/SKILL.md) first for the MCP-first/REST-fallback strategy and authentication.
+Create, update, comment on, link, and close Azure Boards work items. Read [azure-devops-foundation](../azure-devops-foundation/SKILL.md) first for the MCP-first strategy and authentication.
+
+
+## Execution policy
+
+Follow this order for every operation:
+
+1. Use Azure DevOps MCP tools when they are available.
+2. When MCP is unavailable on Windows, use PowerShell 7 with Invoke-RestMethod first. Use native az boards from PowerShell only as the next fallback.
+3. On Linux and macOS, use the REST/CLI fallback described below.
+
+On Windows, never invoke Azure DevOps operations through MSYS2, Git Bash, WSL, bash, or sh. If only one of those shells is available, stop and report that a native PowerShell path is required. Read [Windows-native execution reference](references/windows-native-execution.md) for the encoding-safe command patterns.
+
+Do not rewrite Japanese or other non-English content because captured az output looks corrupted. Redirected output can be encoded with the Windows ANSI code page even when the server data is intact. Read the stored value back with Invoke-RestMethod before diagnosing data loss.
 
 ## When to use
 
@@ -16,6 +28,27 @@ Create, update, comment on, link, and close Azure Boards work items. Read [azure
 - Closing or transitioning work items (close = state transition)
 - Querying work items (saved queries, backlogs, full-text search)
 - Linking work items to each other or to pull requests/commits/builds
+
+
+## Feature-equivalent Wiki gate
+
+Before creating a requirement-level item, query the project process and backlog metadata. Treat these types as Feature-equivalent and require Wiki registration:
+
+- Feature in Agile, Scrum, or CMMI processes
+- Issue in the Basic process, which has no separate Feature type
+- A custom type assigned to the same portfolio/backlog level as Feature
+
+Do not trigger this gate for a User Story, Product Backlog Item, Requirement, Task, or Bug unless the project metadata explicitly maps that type to the Feature level. If the mapping is ambiguous, ask instead of guessing.
+
+For a Feature-equivalent item, follow this sequence:
+
+1. Read [azure-devops-wiki](../azure-devops-wiki/SKILL.md) and discover the existing Wiki, parent page, and page path using read operations. Do not create, rename, reorder, or re-index Wiki structure.
+2. Confirm that the existing placement can be used and that the approved plan has a concrete page destination. If the Wiki or destination cannot be determined, do not create the Work Item.
+3. Create the Work Item hierarchy only after the Wiki preflight succeeds.
+4. Explicitly load and run azure-devops-wiki, handing it the Work Item ID, title, approved plan, and existing page path. Do not duplicate Wiki page-writing logic in this skill or agent.
+5. Read the page back and verify that the registration contains the Work Item ID and approved plan. Report the Feature operation as successful only after this verification.
+
+If an unexpected Wiki write fails after the Work Item exists, do not delete the Work Item. Report the created ID as a partial failure and identify Wiki registration as the required retry.
 
 ## MCP tools (preferred)
 

--- a/plugins/azure-devops-toolkit/skills/azure-devops-boards/agents/openai.yaml
+++ b/plugins/azure-devops-toolkit/skills/azure-devops-boards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Azure DevOps Boards"
+  short_description: "Create process-aware Azure DevOps work items"
+  default_prompt: "Use $azure-devops-boards to register a process-aware work item and apply the required Feature Wiki gate."

--- a/plugins/azure-devops-toolkit/skills/azure-devops-boards/references/windows-native-execution.md
+++ b/plugins/azure-devops-toolkit/skills/azure-devops-boards/references/windows-native-execution.md
@@ -1,0 +1,62 @@
+# Windows-Native Azure DevOps Execution
+
+Use this reference whenever Azure Boards work is executed from Windows, especially on a non-English Windows installation.
+
+## Required shell selection
+
+1. Use Azure DevOps MCP tools when available.
+2. Otherwise run PowerShell 7 (pwsh) and prefer Invoke-RestMethod.
+3. Use the native az boards command from PowerShell only when REST is impractical.
+
+Never use MSYS2, Git Bash, WSL, bash, or sh for Azure DevOps work on Windows. Do not use MSYS_NO_PATHCONV as a workaround; that variable addresses path conversion in a prohibited shell and does not make the shell an approved execution path.
+
+## UTF-8 REST writes
+
+Keep the organization URL, project, and token in environment variables. Do not print the token.
+
+PowerShell example:
+
+    $orgUrl = $env:ADO_ORG_URL.TrimEnd('/')
+    $project = [Uri]::EscapeDataString($env:ADO_PROJECT)
+    $typeName = [Uri]::EscapeDataString($env:ADO_WORK_ITEM_TYPE)
+    $title = $env:ADO_WORK_ITEM_TITLE
+    $description = $env:ADO_WORK_ITEM_DESCRIPTION
+
+    $patch = @(
+        @{ op = 'add'; path = '/fields/System.Title'; value = $title },
+        @{ op = 'add'; path = '/fields/System.Description'; value = $description }
+    )
+    $json = $patch | ConvertTo-Json -Depth 10 -Compress
+    $body = [Text.Encoding]::UTF8.GetBytes($json)
+    $headers = @{ Authorization = "Bearer $env:ADO_TOKEN" }
+    $workItemsSegment = '$' + $typeName
+    $uri = "$orgUrl/$project/_apis/wit/workitems/$workItemsSegment?api-version=7.1"
+
+    $created = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -ContentType 'application/json-patch+json; charset=utf-8' -Body $body
+    $created.id
+
+Use the same UTF-8 byte conversion for JSON Patch updates and relation links. Read the created item back with Invoke-RestMethod; PowerShell returns the response as Unicode text without relying on the console code page.
+
+## Native az boards fallback
+
+Use az boards directly from PowerShell and retrieve only an ASCII ID when possible:
+
+    $createdId = az boards work-item create --type $env:ADO_WORK_ITEM_TYPE --title $env:ADO_WORK_ITEM_TITLE --description $env:ADO_WORK_ITEM_DESCRIPTION --query id -o tsv
+
+Verify fields with Invoke-RestMethod rather than trusting captured human-readable az output. Azure CLI's MSI launcher uses Python isolated mode, which ignores PYTHONIOENCODING; redirected output can therefore use the Windows ANSI code page. chcp 65001 changes the console code page and does not repair redirected output. Neither behavior means that the server received corrupted data.
+
+If az emits an encoding warning, preserve the original title and description, read the Work Item through REST, and compare the returned fields. Never translate content to English as an encoding workaround.
+
+## Linux/macOS comparison
+
+The following pattern is for Linux/macOS shells only. It must not be copied into a Windows MSYS2 or Git Bash session.
+
+    base_uri="$ADO_ORG_URL/$ADO_PROJECT"
+    json="$PATCH_JSON"
+    curl --fail-with-body -sS -X POST \
+      -H "Authorization: Bearer $ADO_TOKEN" \
+      -H 'Content-Type: application/json-patch+json; charset=utf-8' \
+      --data-binary "$json" \
+      "$base_uri/_apis/wit/workitems/\$$ADO_WORK_ITEM_TYPE?api-version=7.1"
+
+When a Windows session cannot provide PowerShell 7, stop and request that the user run the operation from a native PowerShell environment. Do not silently switch to MSYS2.

--- a/plugins/azure-devops-toolkit/skills/azure-devops-boards/references/windows-native-execution.md
+++ b/plugins/azure-devops-toolkit/skills/azure-devops-boards/references/windows-native-execution.md
@@ -12,7 +12,7 @@ Never use MSYS2, Git Bash, WSL, bash, or sh for Azure DevOps work on Windows. Do
 
 ## UTF-8 REST writes
 
-Keep the organization URL, project, and token in environment variables. Do not print the token.
+Keep the organization URL, project, and credential in environment variables. In the PowerShell example below, `ADO_TOKEN` must be an Entra ID access token because it is sent as a Bearer token. A PAT is not a Bearer token; use an `Authorization: Basic` header with the PAT instead, following the authentication guidance in the foundation skill. Never print credentials.
 
 PowerShell example:
 


### PR DESCRIPTION
Closes #30

Relates to #31
Relates to #32
Relates to #33

## Summary

- Prefer PowerShell Invoke-RestMethod and native az boards on Windows.
- Prohibit MSYS2, Git Bash, WSL, bash, and sh for Windows Azure DevOps operations.
- Preserve non-English Work Item data and verify captured az output through REST.
- Require Wiki preflight, delegated registration, and read-back verification for Feature-equivalent Work Items.
- Synchronize canonical and .github mirrors and release azure-devops-toolkit 0.2.0.

## Validation

- Repository Marketplace validation is covered by the pull request workflow.
- The skill frontmatter is compatible with skill-creator validation.
- Live Azure DevOps writes were not performed.